### PR TITLE
Fix asset target directory name

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ https://nekotaku.nekometer.info
   $ NODE_ENV=production yarn build
   ```
 
-6. Deploy `<your-nekotaku-directory>/public` into your server.
+6. Deploy `<your-nekotaku-directory>/dist` into your server.
 
 ### D. Standalone Server with MongoDB
 1. Requirements:


### PR DESCRIPTION
静的コンテンツにCacheControlヘッダを付加できるようにnginx経由で配布しようとしてドハマりしましたが、今のバージョンはここに作成されますよね？