### PR TITLE
Dockernize

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+dist
+node_modules
+lib

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 /node_modules
 /public/assets
 /*.log
+/mongo
+*.swp

--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,5 @@
 /node_modules
 /public/assets
 /*.log
-/mongo
+/data/db
 *.swp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:10-alpine
+
+RUN apk add --no-cache curl && \
+    curl -L https://yarnpkg.com/install.sh | sh
+
+ENV APP_PATH /usr/src/app/
+WORKDIR $APP_PATH
+
+COPY package.json package.json
+COPY yarn.lock yarn.lock
+RUN yarn install
+
+COPY . $APP_PATH
+COPY config/config.server.json config/config.json
+COPY config/server.mongodb.json config/server.json
+RUN sed -i -e 's/localhost:27017/db:27017/' -e 's/localhost/0.0.0.0/' config/server.json
+RUN yarn build
+
+ADD https://github.com/ufoscout/docker-compose-wait/releases/download/2.5.0/wait /wait
+RUN chmod +x /wait

--- a/README.md
+++ b/README.md
@@ -112,6 +112,16 @@ https://nekotaku.nekometer.info
   $ node index.js
   ```
 
+### E. Docker Compose
+1. Build Docker Image.
+  ```
+  $ docker-compose build
+  ```
+2. Run.
+  ```
+  $ docker-compose up
+  ```
+
 ## 設定 / Configuration
 ### `config/config.json`
 ```js

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+version: '2'
+services:
+  web:
+    tty: true
+    stdin_open: true
+    build:
+      context: .
+    image: nekotaku-dev:latest
+    environment:
+      - NODE_ENV=production
+      - WAIT_HOSTS=db:27017
+    restart: always
+    ports:
+      - "8080:8080"
+    depends_on:
+      - "db"
+    command: sh -c '/wait && node index.js'
+  db:
+    image: mongo:4-xenial
+    volumes:
+      - mongo-db:/data
+    restart: always
+
+volumes:
+  mongo-db:
+    driver_opts:
+      type: none
+      device: ${PWD}/mongo/data
+      o: bind

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,12 +18,6 @@ services:
   db:
     image: mongo:4-xenial
     volumes:
-      - mongo-db:/data
+      - ./data/db:/data/db
     restart: always
-
-volumes:
-  mongo-db:
-    driver_opts:
-      type: none
-      device: ${PWD}/mongo/data
-      o: bind
+    command: bash -c 'usermod -o -u 1000 mongodb; groupmod -o -g 500 mongodb; chown -R mongodb:root /data/db; /usr/local/bin/docker-entrypoint.sh mongod'


### PR DESCRIPTION
node 環境を自前で用意するのが面倒だったので、Dockernize しました。~が、思ったよりも時間がかかったため、node 環境を apt で入れたほうが早かったです…~
検証はLinux(Ubuntu 18.04.1) でしか行ってないです。多分、Windows だと、`${PWD}` が使えなくて、docker-compose up できないです。
データは`mongo`ディレクトリに永続化されるので、再起動しても残ってます。